### PR TITLE
註冊與登錄調 API 邏輯

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -18,7 +18,9 @@ module.exports = {
     'react-refresh/only-export-components': [
       'warn',
       { allowConstantExport: true }
-    ]
+    ],
+    'no-console': ['error', { allow: ['warn', 'error'] }],
+    '@typescript-eslint/consistent-type-definitions': 'off'
   },
   parserOptions: {
     ecmaVersion: 'latest',

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useSubmit } from './useSubmit'

--- a/src/hooks/useSubmit.tsx
+++ b/src/hooks/useSubmit.tsx
@@ -1,0 +1,8 @@
+export default function useSubmit<T>(callback: (values: T) => void) {
+  return (event: React.FormEvent) => {
+    event.preventDefault()
+
+    const data = new FormData(event.currentTarget as HTMLFormElement)
+    return callback(Object.fromEntries(data.entries()) as T)
+  }
+}

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,31 +1,40 @@
+import { useMutation } from '@tanstack/react-query'
+
 import { userStore } from '@stores'
+import { useSubmit } from '@hooks'
+import { getUserLoginInfo } from '@services/queries'
+import { postUserRegisterInfo } from '@services/mutations'
+import type { RegisterRequest } from '@services/types'
 import type { ActionType } from '@stores/userStore'
 
-const fields: Record<ActionType, { id: string; name: string }[]> = {
-  login: [
-    {
-      id: 'account',
-      name: '帳號'
-    },
-    {
-      id: 'password',
-      name: '密碼'
-    }
-  ],
-  register: [
-    {
-      id: 'account',
-      name: '帳號'
-    },
-    {
-      id: 'password',
-      name: '密碼'
-    },
-    {
-      id: 'confirmPassword',
-      name: '確認密碼'
-    }
-  ]
+const FeatureFlag = {
+  register_confirm_password_field: false
+}
+
+enum FIELDS {
+  ACCOUNT = 'account',
+  PASSWORD = 'password',
+  CONFIRM_PASSWORD = 'confirmPassword'
+}
+
+const fields: FIELDS[] = FeatureFlag.register_confirm_password_field
+  ? [FIELDS.ACCOUNT, FIELDS.PASSWORD, FIELDS.CONFIRM_PASSWORD]
+  : [FIELDS.ACCOUNT, FIELDS.PASSWORD]
+
+const display = {
+  [FIELDS.ACCOUNT]: true,
+  [FIELDS.PASSWORD]: true,
+  [FIELDS.CONFIRM_PASSWORD]: false
+}
+const textKey: Record<FIELDS, string> = {
+  account: '帳號',
+  password: '密碼',
+  confirmPassword: '確認密碼'
+}
+const typeKey: Record<FIELDS, string> = {
+  account: 'text',
+  password: 'password',
+  confirmPassword: 'password'
 }
 
 const buttons: Record<ActionType, { id: 'button' | 'submit'; text: string }[]> =
@@ -54,23 +63,49 @@ const buttons: Record<ActionType, { id: 'button' | 'submit'; text: string }[]> =
 
 function Login() {
   const { actionType, setActionType } = userStore()
+  const mutation = useMutation({
+    mutationFn: (payload: string | RegisterRequest) => {
+      return actionType === 'login'
+        ? getUserLoginInfo(payload as string)
+        : postUserRegisterInfo(payload as RegisterRequest)
+    }
+  })
 
-  const onSubmit = (event: React.FormEvent) => {
-    event.preventDefault()
-  }
+  const handleSubmit = useSubmit((data: Record<FIELDS, string>) => {
+    if (actionType === 'login') {
+      mutation.mutate(data.account)
+    } else {
+      mutation.mutate({
+        account: data.account,
+        passWord: data.password,
+        level: 0
+      })
+    }
+  })
+
+  actionType === 'register'
+    ? (display[FIELDS.CONFIRM_PASSWORD] = true)
+    : (display[FIELDS.CONFIRM_PASSWORD] = false)
 
   return (
     <main className="w-screen h-screen flex justify-center items-center">
       <form
-        onSubmit={onSubmit}
+        onSubmit={handleSubmit}
         className="flex flex-col items-center justify-center gap-10"
       >
-        {fields[actionType].map(({ id, name }) => (
-          <label key={id}>
-            <p>{name}</p>
-            <input id={id} className="border-2 border-slate-500" type="text" />
-          </label>
-        ))}
+        {fields
+          .filter((field) => display[field])
+          .map((field) => (
+            <label key={field}>
+              <p>{textKey[field]}</p>
+              <input
+                id={field}
+                className="border-2 border-slate-500"
+                type={typeKey[field]}
+                name={field}
+              />
+            </label>
+          ))}
         <ul className="flex gap-10">
           {buttons[actionType].map(({ id, text }) => (
             <li key={id}>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,21 +1,5 @@
 const baseUrl = 'http://34.80.254.154:8080'
 
-export const get = async <T>(path: string): Promise<T> => {
-  const reqUrl = new URL(path, baseUrl)
-  const response = await fetch(reqUrl.href, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json'
-    }
-  })
-  if (!response.ok) {
-    throw new Error('Network response was not ok')
-  }
-  const res: ApiResponse<T> =
-    (await response.json()) as unknown as ApiResponse<T>
-  return res.data
-}
-
 interface ApiResponse<T> {
   status: Status
   code: StatusCode
@@ -31,4 +15,54 @@ enum Status {
 enum StatusCode {
   OK = 200,
   ERROR = 404
+}
+
+export const get = async <T, Q = undefined>(
+  path: string,
+  queries?: Q
+): Promise<T> => {
+  const reqUrl = new URL(path, baseUrl)
+  if (queries) {
+    // 添加參數
+    reqUrl.search = new URLSearchParams(queries).toString()
+  }
+  try {
+    const response = await fetch(reqUrl.href, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    })
+    if (!response.ok) {
+      throw new Error('Network response was not ok')
+    }
+    const res: ApiResponse<T> =
+      (await response.json()) as unknown as ApiResponse<T>
+    return res.data
+  } catch (error) {
+    console.error('Get operation failed: ', (error as Error).message)
+    throw error
+  }
+}
+
+export const post = async <P, T>(path: string, params: P): Promise<T> => {
+  const reqUrl = new URL(path, baseUrl)
+  try {
+    const response = await fetch(reqUrl.href, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(params)
+    })
+    if (!response.ok) {
+      throw new Error('Network response was not ok')
+    }
+    const res: ApiResponse<T> =
+      (await response.json()) as unknown as ApiResponse<T>
+    return res.data
+  } catch (error) {
+    console.error('Post operation failed: ', (error as Error).message)
+    throw error
+  }
 }

--- a/src/services/mutations.ts
+++ b/src/services/mutations.ts
@@ -1,0 +1,9 @@
+import { post } from './api'
+import type * as ApiType from './types'
+
+export const postUserRegisterInfo = async (data: ApiType.RegisterRequest) => {
+  return await post<ApiType.RegisterRequest, ApiType.RegisterResponse>(
+    '/user/add',
+    data
+  )
+}

--- a/src/services/queries.ts
+++ b/src/services/queries.ts
@@ -1,0 +1,12 @@
+import { get } from './api'
+import type * as ApiType from './types'
+
+export const fetchAllShops = async (): Promise<ApiType.Shop[]> => {
+  return await get<ApiType.Shop[]>('/shop/selectAll')
+}
+
+export const getUserLoginInfo = async (
+  param: string
+): Promise<ApiType.LoginResponse> => {
+  return await get<ApiType.LoginResponse>('/user/selectByAccount/' + param)
+}

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1,0 +1,35 @@
+export type Shop = {
+  shopName: string
+  phone: string
+  address: string
+  image: string
+  lastUpdated: string
+}
+
+export type RegisterRequest = {
+  userID?: number
+  account: string
+  passWord: string
+  phone?: string
+  userName?: string
+  image?: string
+  level: number
+  createTime?: string
+  updateTime?: string
+}
+
+export type RegisterResponse = {
+  userID: number
+}
+
+export type LoginResponse = {
+  userID: number
+  account: string
+  passWord: string
+  phone: string | null
+  userName: string | null
+  image: string | null
+  level: 1 | 0 // 1 管理員 0 普通用戶
+  createTime: string
+  updateTime: string
+}


### PR DESCRIPTION
### 描述

1. 新增 post 語法，並順便將 get 內部的邏輯做修改。
2. 新增 types 檔案，用以存放 request 跟 response 的型別。
3. 新增 useSubmit hook 用以處理表單欄位。

### 補充
單元測試部分之後找時間補上
